### PR TITLE
hay que cambiar todos los costrucoters que necesitan un objeto 

### DIFF
--- a/S303-EscapeRoom/src/main/java/org/example/Repository/Common/RepositoryImpl.java
+++ b/S303-EscapeRoom/src/main/java/org/example/Repository/Common/RepositoryImpl.java
@@ -44,17 +44,14 @@ public class RepositoryImpl implements Repository{
     @Override
     public ArrayList<Entity> getAll(EntityAttributes enumAttributes) throws SQLException {
         String tableName = enumAttributes.name();
-        String query = "SELECT * FROM escaperoomdb." + tableName +";";
-        logger.info(query);
+        String query = "SELECT * FROM escaperoomdb." + tableName + " WHERE " + tableName + "_deleted = 0;";
         return Serializer.deserializeGetAll(query, enumAttributes);
     }
-
 
     @Override
     public Entity getById(int id, EntityAttributes enumAttributes) throws SQLException {
         String tableName = enumAttributes.name();
-        String attribute = enumAttributes.getAttributes().getFirst();
-        String query = "SELECT * FROM escaperoomdb." + tableName + " WHERE " + attribute + " = " + id + ";";
+        String query = "SELECT * FROM escaperoomdb." + tableName + " WHERE " + tableName + "_id = " + id + ";";
         return deserialize(query, enumAttributes);
     }
 

--- a/S303-EscapeRoom/src/main/java/org/example/Repository/Serializers/Serializer.java
+++ b/S303-EscapeRoom/src/main/java/org/example/Repository/Serializers/Serializer.java
@@ -22,17 +22,18 @@ public class Serializer {
 
     public static Map<String, Object> deserialize(ResultSet resultSet, EntityAttributes entityEnum) throws SQLException {
         Map<String, Object> entityData = new HashMap<>();
-        //logger.info("Deserializando ResultSet...");
+        logger.info("Deserializando ResultSet...");
 
         for (String attribute : entityEnum.getAttributes()) {
             try {
                 Object value = resultSet.getObject(attribute);
-
+                logger.info("Columna: " + attribute + " Valor: " + value);  // Ver qué datos tienes
                 entityData.put(attribute, value);
             } catch (SQLException e) {
                 logger.info("Error al obtener el valor de la columna " + attribute + ": " + e.getMessage());
             }
         }
+
         return entityData;
     }
 
@@ -43,8 +44,12 @@ public class Serializer {
              ResultSet resultSet = statement.executeQuery()) {
 
             if (resultSet.next()) {
+                // Primero deserializamos el ResultSet a un Map
                 Map<String, Object> entityData = deserialize(resultSet, entityEnum);
+
+                // Luego creamos la entidad a partir del Map
                 entity = createEntityToDeserialize(entityEnum, entityData);
+                return entity;
             } else {
                 throw new SQLException("No data found for the given ID.");
             }
@@ -52,7 +57,6 @@ public class Serializer {
             logger.error("Error during deserialization: ", e);
             throw e;
         }
-        return entity;
     }
 
     public static ArrayList<Entity> deserializeGetAll(String query, EntityAttributes entityEnum) throws SQLException {

--- a/S303-EscapeRoom/src/main/java/org/example/Services/GameServices/GameService.java
+++ b/S303-EscapeRoom/src/main/java/org/example/Services/GameServices/GameService.java
@@ -113,10 +113,10 @@ public class GameService {
         ArrayList<Game> gameArrayList = new ArrayList<>();
         try{
 
-        this.repository
+            this.repository
                 .getAll(EntityAttributes.game)
                 .forEach(game -> gameArrayList.add((Game) game));
-        return gameArrayList;
+            return gameArrayList;
         }catch (SQLException e){
             logger.info(e.getMessage());
             return null;

--- a/S303-EscapeRoom/src/test/java/ServicesTesting.java
+++ b/S303-EscapeRoom/src/test/java/ServicesTesting.java
@@ -9,6 +9,8 @@ import org.example.Modules.Entities.GameEntities.Sale;
 import org.example.Modules.Entities.RoomEntities.ObjectDeco;
 import org.example.Modules.Entities.RoomEntities.Room;
 import org.example.Modules.Entities.RoomEntities.Tips;
+import org.example.Repository.Common.EntityAttributes;
+import org.example.Repository.Common.RepositoryImpl;
 import org.example.Services.CommunicatesServices.CertificateService;
 import org.example.Services.CommunicatesServices.GiftService;
 import org.example.Services.CommunicatesServices.NotificationService;
@@ -24,6 +26,7 @@ import org.example.Services.GameServices.SaleService;
 import org.junit.Test;
 import org.junit.jupiter.api.DisplayName;
 
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
@@ -61,6 +64,13 @@ public class ServicesTesting {
     public void getCertificate() {
         CertificateService commService = new CertificateService();
         Certificate certificate = commService.getCertificateById(1);
+        System.out.println(certificate);
+    }
+
+    @Test
+    public void getCertificateDesdeRepo() throws SQLException {
+        RepositoryImpl repo = new RepositoryImpl();
+        Certificate certificate = (Certificate) repo.getById(2, EntityAttributes.certificate);
         System.out.println(certificate);
     }
 


### PR DESCRIPTION
para que solo necesiten el id de ese objeto y dentro del objeto dengas listas de id de ese objeto asi no romperá el deserialize a la hora de volver a ejecutarse para crear el objeto necesario.

Ejemplo:
al crear un ticket se recibe el id del playr, entonces va a rear en el constructor el Ticket con un player asignado, el cual vuelve a llamar al deserialize y crea el player, cuando crea el player y lo asigna al constructor del ticket vuelve al deserialize anterior del ticket y ya el map y el resultset estan vacios de vuelta , con lo cual da null